### PR TITLE
Use version 2.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>dev.hilla</groupId>
     <artifactId>sso-kit-hilla</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sso-kit-hilla-demo/pom.xml
+++ b/sso-kit-hilla-demo/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>dev.hilla</groupId>
         <artifactId>sso-kit-hilla</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>sso-kit-hilla-demo</artifactId>
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>dev.hilla</groupId>
             <artifactId>sso-kit-hilla-starter</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>dev.hilla</groupId>

--- a/sso-kit-hilla-starter/pom.xml
+++ b/sso-kit-hilla-starter/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>dev.hilla</groupId>
         <artifactId>sso-kit-hilla</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>sso-kit-hilla-starter</artifactId>


### PR DESCRIPTION
As we're going to support both Hilla 2.0 and 1.3, it makes sense to have at least the major version match the Hilla one